### PR TITLE
User can select app and/or role to AWS from browser in addition of giving them as cmdline params

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,31 @@ source_profile=<the profile name in ~/.aws/crendentials you log in to>
 role_arn=<arn for the role to assume>
 ```
 
+## Usage
+
+Option `--profile` is mandatory.
+
+```
+Usage: ${0} [OPTIONS]
+
+  Simple script that fetches temporary AWS credentials with Azude AD login
+  (https://myapps.microsoft.com).
+
+Options:
+  --profile  TEXT    The name of the profile in ~/.aws/credentials to update.
+  --app      TEXT    A substring of the app name shown in myapps.microsoft.com
+                     to launch. Case-insensitive. Must be url encoded.
+  --duration INTEGER How many hours the temporary credentials are valid.
+  --role-arn TEXT    AWS IAM Role to assume with AD credentials.
+```
+
 ## Example
 
 Log in to your sandbox account. Assuming the link to the sandbox account in
 myapps.microsoft.com is called "AWS test", then `--app` argument should be
-"AWS%20test". Write temporary credentials to `~/.aws/credentials` under a
-profile called `sandbox`:
+"AWS%20test". If `--app` or `--role` is missing from parameters, you are asked
+to select them in browser. Write temporary credentials to `~/.aws/credentials`
+under a profile called `sandbox`:
 
 ```
 ./ad-aws-login.sh --profile sandbox --app "AWS%20test" --duration-hours 4 --role-arn arn:aws:iam::123456789012:role/Developer

--- a/README.md
+++ b/README.md
@@ -1,20 +1,30 @@
 # Azure AD Login to AWS
 
-The `ad-aws-login.sh` script fetches temporary AWS credentials with Azude AD login (https://myapps.microsoft.com).
+The `ad-aws-login.sh` script fetches temporary AWS credentials with Azude AD
+login (https://myapps.microsoft.com).
 
 So far this has been used **only on OS X**.
 
-The script launches Chrome with a separate session and helps you through the login with a dedicated Chrome extension.
-Because this is a new session, Chrome will ask you about default browser etc.
-And if you choose "Remember me" on the first login, you don't need to enter your username all the time.
+The script launches Chrome with a separate session and helps you through the
+login with a dedicated Chrome extension. Because this is a new session,
+Chrome will ask you about default browser etc. And if you choose "Remember
+me" on the first login, you don't need to enter your username all the time.
 
-The motivation for all this was to get rid of the host of dependencies aws-azure-login requires.
-Now the codebase is compact enough that you can read it through, and verify that is not malicious.
-(apart from minified aws sdk which you can download yourself from https://github.com/aws/aws-sdk-js/releases)
+The motivation for all this was to get rid of the host of dependencies
+[aws-azure-login](https://github.com/sportradar/aws-azure-login) requires.
+Now the codebase is compact enough that you can read it through, and verify
+that is not malicious. (apart from minified aws sdk which you can download
+yourself from https://github.com/aws/aws-sdk-js/releases)
 
-The script adds temporary credentials to `~/.aws/credentials`. You can then use those credentials by setting your `AWS_PROFILE` environment variable accordingly.
+## How it works
 
-Logging in gets you into the role you've been assigned to by default. To assume other roles, it's recommended you have a section in `~/.aws/config` for each role you're going to use. Something like this:
+The script adds temporary credentials to `~/.aws/credentials`. You can then
+use those credentials by setting your `AWS_PROFILE` environment variable
+accordingly.
+
+Logging in gets you into the role you've been assigned to by default. To
+assume other roles, it's recommended you have a section in `~/.aws/config`
+for each role you're going to use. Something like this:
 
 ```
 [profile <profile name for role to assume>]
@@ -23,9 +33,12 @@ source_profile=<the profile name in ~/.aws/crendentials you log in to>
 role_arn=<arn for the role to assume>
 ```
 
-## Usage example
+## Example
 
-Log in to your sandbox account. Assuming the link to the sandbox account in myapps.microsoft.com is called "AWS test", then `--app` argument should be "AWS%20test". Write temporary credentials to `~/.aws/credentials` under a profile called `sandbox`
+Log in to your sandbox account. Assuming the link to the sandbox account in
+myapps.microsoft.com is called "AWS test", then `--app` argument should be
+"AWS%20test". Write temporary credentials to `~/.aws/credentials` under a
+profile called `sandbox`:
 
 ```
 ./ad-aws-login.sh --profile sandbox --app "AWS%20test" --duration-hours 4 --role-arn arn:aws:iam::123456789012:role/Developer
@@ -35,9 +48,14 @@ unset AWS_SESSION_TOKEN AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
 export AWS_PROFILE=sandbox
 ```
 
-**Note** Your account probably has some maximum session duration. Trying to use longer `--duration-hours` will cause the script to get stuck.
+**Note** Your account probably has some maximum session duration. Trying to
+use longer `--duration-hours` will cause the script to get stuck.
 
 **Pro tip:** Put this in a bash alias or script.
 
 ## TODO
- * Downloading the credentials from chrome as a file is not that neat. Is there some other communication channel? What changes to chrome extension would enable it to write the file directly? (`~/.aws` is about as safe as `~/Downloads` so I think this is a matter of style)
+
+* Downloading the credentials from chrome as a file is not that neat. Is there
+  some other communication channel? What changes to chrome extension would
+  enable it to write the file directly? (`~/.aws` is about as safe as
+  `~/Downloads` so I think this is a matter of style)

--- a/ad-aws-login.sh
+++ b/ad-aws-login.sh
@@ -57,7 +57,7 @@ if [ -z $APP_NAME ]; then
 fi
 
 THIS_DIR="$( cd "$( dirname "$0" )" && pwd )"
-EXTENSION=$THIS_DIR/chrome_extension
+EXTENSION="$THIS_DIR/chrome_extension"
 
 TIMESTAMP="$(date +"%Y-%m-%d_%H-%M-%S")"
 TEMP_FILENAME=temporary_aws_credentials${TIMESTAMP}.txt
@@ -66,12 +66,12 @@ rm -f $TEMP_FILE
 
 # if chrome is already open, we would get just new tab without our extensions,
 # unless we use custom --user-data-dir
-USER_DATA_DIR=$THIS_DIR/user_data
-mkdir -p $USER_DATA_DIR
+USER_DATA_DIR="$THIS_DIR/user_data"
+mkdir -p "$USER_DATA_DIR"
 
 /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
-    --load-extension=$EXTENSION --disable-extensions-except=$EXTENSION \
-    --user-data-dir=$USER_DATA_DIR \
+    --load-extension="$EXTENSION" --disable-extensions-except="$EXTENSION" \
+    --user-data-dir="$USER_DATA_DIR" \
     'http://localhost/?durationHours='$DURATION_HOURS'&app='$APP_NAME'&filename='$TEMP_FILENAME'&roleArn='$ROLE_ARN 2>/dev/null &
 
 PID=$!

--- a/ad-aws-login.sh
+++ b/ad-aws-login.sh
@@ -1,7 +1,6 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-set -e
-set -u
+set -euo pipefail
 
 PROFILE_NAME=
 APP_NAME=
@@ -16,7 +15,7 @@ function usage() {
     echo "        Case-insensitive. Must be url encoded (replace spaces with %20)."
     echo "  --duration-hours How long the temporary credentials are valid"
     echo "  --role-arn AWS IAM Role to assume with AD credentials"
-    exit 1
+    exit 128
 }
 
 

--- a/ad-aws-login.sh
+++ b/ad-aws-login.sh
@@ -80,6 +80,7 @@ rm -f $TEMP_FILE
 # unless we use custom --user-data-dir
 USER_DATA_DIR="$THIS_DIR/user_data"
 mkdir -p "$USER_DATA_DIR"
+trap "rm -f ${TEMP_FILE}" EXIT
 
 /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
     --load-extension="$EXTENSION" --disable-extensions-except="$EXTENSION" \
@@ -102,10 +103,10 @@ if [ -e $TARGET_FILE ]; then
   # delete section with old values, if any
   awk '/^\[/{keep=1} /^\['$PROFILE_NAME'\]/{keep=0} {if (keep) {print $0}}' $TARGET_FILE.bak > ${TARGET_FILE}
 fi
+
 # add new values
-echo "\n[$PROFILE_NAME]" >> ${TARGET_FILE}
+echo -e "\n[$PROFILE_NAME]" >> ${TARGET_FILE}
 cat $TEMP_FILE >> ${TARGET_FILE}
-rm $TEMP_FILE
 
 echo "Updated profile $PROFILE_NAME."
 tail -1 ${TARGET_FILE}

--- a/ad-aws-login.sh
+++ b/ad-aws-login.sh
@@ -52,6 +52,18 @@ if [ -z $PROFILE_NAME ]; then
     usage
 fi
 
+# Check that AWS config and selected profile exists.
+AWS_CONFIG="${HOME}/.aws/config"
+if [ ! -f "${AWS_CONFIG}" ]; then
+    echo "AWS config file (${AWS_CONFIG}) does not exist. Cannot continue."
+    exit 1
+fi
+
+if ! cat "${AWS_CONFIG}" | grep -q "^\[profile ${PROFILE_NAME}\]$"; then
+    echo "Profile ${PROFILE_NAME} not found."
+    exit 2
+fi
+
 if [ -z $APP_NAME ]; then
     echo "--app-name not specified. Now you must select app manually."
 fi

--- a/ad-aws-login.sh
+++ b/ad-aws-login.sh
@@ -1,5 +1,4 @@
-#!/usr/bin/env bash
-
+#!/usr/bin/env bash 
 set -euo pipefail
 
 PROFILE_NAME=
@@ -8,16 +7,21 @@ DURATION_HOURS=4
 ROLE_ARN=
 
 function usage() {
-    echo "Usage: ad-aws-login.sh --profile <profile name> --app <app name>"
-    echo "Options:"
-    echo "  --profile  The name of the profile in ~/.aws/credentials to update"
-    echo "  --app A substring of the app name shown in myapps.microsoft.com to launch."
-    echo "        Case-insensitive. Must be url encoded (replace spaces with %20)."
-    echo "  --duration-hours How long the temporary credentials are valid"
-    echo "  --role-arn AWS IAM Role to assume with AD credentials"
+    cat <<EOF
+Usage: ${0} [OPTIONS]
+
+  Simple script that fetches temporary AWS credentials with Azude AD login
+  (https://myapps.microsoft.com).
+
+Options:
+  --profile  TEXT    The name of the profile in ~/.aws/credentials to update.
+  --app      TEXT    A substring of the app name shown in myapps.microsoft.com
+                     to launch. Case-insensitive. Must be url encoded.
+  --duration INTEGER How many hours the temporary credentials are valid.
+  --role-arn TEXT    AWS IAM Role to assume with AD credentials.
+EOF
     exit 128
 }
-
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -48,7 +52,6 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [ -z $PROFILE_NAME ]; then
-    echo "Must specify profile name."
     usage
 fi
 
@@ -60,7 +63,7 @@ if [ ! -f "${AWS_CONFIG}" ]; then
 fi
 
 if ! cat "${AWS_CONFIG}" | grep -q "^\[profile ${PROFILE_NAME}\]$"; then
-    echo "Profile ${PROFILE_NAME} not found."
+    echo "Profile ${PROFILE_NAME} not found in ${AWS_CONFIG}."
     exit 2
 fi
 
@@ -86,11 +89,7 @@ mkdir -p "$USER_DATA_DIR"
     --user-data-dir="$USER_DATA_DIR" \
     'http://localhost/?durationHours='$DURATION_HOURS'&app='$APP_NAME'&filename='$TEMP_FILENAME'&roleArn='$ROLE_ARN 2>/dev/null &
 
-PID=$!
-echo $PID
-
-while [ ! -f $TEMP_FILE ]
-do
+while [ ! -f $TEMP_FILE ]; do
   sleep 1
 done
 

--- a/ad-aws-login.sh
+++ b/ad-aws-login.sh
@@ -43,7 +43,7 @@ while [[ $# -gt 0 ]]; do
             shift
             shift
             ;;
-        -d|--duration-hours)
+        -d|--duration)
             DURATION_HOURS=$2
             shift
             shift

--- a/ad-aws-login.sh
+++ b/ad-aws-login.sh
@@ -12,9 +12,7 @@ readonly AWS_CREDENTIALS=~/.aws/credentials
 readonly THIS_DIR="$( cd "$( dirname "$0" )" && pwd )"
 readonly EXTENSION="$THIS_DIR/chrome_extension"
 readonly USER_DATA_DIR="$THIS_DIR/user_data"
-readonly TIMESTAMP="$(date +"%Y-%m-%d_%H-%M-%S")"
-readonly TEMP_FILENAME=temporary_aws_credentials${TIMESTAMP}.txt
-readonly TEMP_FILE=~/Downloads/$TEMP_FILENAME
+readonly TEMP_FILE="${HOME}/Downloads/temporary_aws_credentials$(date +"%Y-%m-%d_%H-%M-%S").txt"
 
 function usage() {
     cat <<EOF
@@ -85,7 +83,7 @@ mkdir -p "$USER_DATA_DIR"
 /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
     --load-extension="$EXTENSION" --disable-extensions-except="$EXTENSION" \
     --user-data-dir="$USER_DATA_DIR" \
-    'http://localhost/?durationHours='$DURATION_HOURS'&app='$APP_NAME'&filename='$TEMP_FILENAME'&roleArn='$ROLE_ARN 2>/dev/null &
+    'http://localhost/?durationHours='$DURATION_HOURS'&app='$APP_NAME'&filename='$(basename ${TEMP_FILE})'&roleArn='$ROLE_ARN 2>/dev/null &
 
 while [ ! -f $TEMP_FILE ]; do
   sleep 1

--- a/ad-aws-login.sh
+++ b/ad-aws-login.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash 
+#!/usr/bin/env bash
 
 set -euo pipefail
 
@@ -29,6 +29,10 @@ Options:
   --role-arn TEXT    AWS IAM Role to assume with AD credentials.
 EOF
     exit 128
+}
+
+function err() {
+    echo "$@" >&2
 }
 
 while [[ $# -gt 0 ]]; do
@@ -65,12 +69,12 @@ fi
 
 # Check that AWS config and selected profile exists.
 if [ ! -f "${AWS_CONFIG}" ]; then
-    echo "AWS config file (${AWS_CONFIG}) does not exist. Cannot continue."
+    err "AWS config file (${AWS_CONFIG}) does not exist. Cannot continue."
     exit 1
 fi
 
 if ! cat "${AWS_CONFIG}" | grep -q "^\[profile ${PROFILE_NAME}\]$"; then
-    echo "Profile ${PROFILE_NAME} not found in ${AWS_CONFIG}."
+    err "Profile ${PROFILE_NAME} not found in ${AWS_CONFIG}."
     exit 2
 fi
 

--- a/chrome_extension/background.js
+++ b/chrome_extension/background.js
@@ -29,14 +29,18 @@ aws_session_expiration=${credentials.Expiration.toJSON()}
         })
     }
 
-    chrome.runtime.onMessage.addListener(
-        function(request, sender, sendResponse) {
-            if (request.type === 'AWS_AD_credentials_fetcher_get_parameter') {
-                sendResponse(parameters[request.key])
-            }
-            return true;
+    chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
+        if (request.type === 'AWS_AD_credentials_fetcher_get_parameter') {
+            sendResponse(parameters[request.key])
         }
-    );
+        if (request.type === "AWS_AD_credentials_get_role") {
+            sendResponse(parameters[request.key])
+        }
+        if (request.type === 'AWS_AD_Credentials_set_role') {
+            parameters.roleArn = request.roleArn;
+        }
+        return true;
+    });
 
     function onBeforeRequestListener(details) {
         if (details.url.startsWith('http://localhost/')) {
@@ -82,7 +86,7 @@ aws_session_expiration=${credentials.Expiration.toJSON()}
                 saveCredentials(data.Credentials);
             }
         });
-
+        
         // prevent going to aws
         return {redirectUrl: 'javascript:void(0)'}
     }

--- a/chrome_extension/background.js
+++ b/chrome_extension/background.js
@@ -55,13 +55,11 @@ aws_session_expiration=${credentials.Expiration.toJSON()}
 
         const SAMLResponse = details.requestBody.formData.SAMLResponse[0]
         var re = null;
+        var arn = null;
         if (parameters.roleArn) {
             re = new RegExp("\<Attribute Name\=\"https\:\/\/aws\.amazon\.com\/SAML\/Attributes\/Role\"\>.*\<AttributeValue\>" + parameters.roleArn + ",([^<]+)\<\/AttributeValue\>.*\<\/Attribute\>");
-        } else {
-            //assume one role in SAML
-            re = new RegExp("\<Attribute Name\=\"https\:\/\/aws\.amazon\.com\/SAML\/Attributes\/Role\"\>\<AttributeValue\>([^,]+),([^<]+)\<\/AttributeValue\>\<\/Attribute\>");
+            arn = atob(SAMLResponse).match(re);
         }
-        const arn = atob(SAMLResponse).match(re);
         if (!arn) {
             console.error("Could not parse role / principal from SAML");
         }

--- a/chrome_extension/manifest.json
+++ b/chrome_extension/manifest.json
@@ -1,21 +1,16 @@
 {
+  // Required
   "manifest_version": 2,
   "name": "AWS AD credentials fetcher",
   "version": "1.0",
-  "permissions": [
-    "webRequest",
-    "*://*/*",
-    "webRequestBlocking",
-    "downloads",
-    "tabs",
-    "contentSettings"
-  ],
+
+  // Optional
   "background": {
-    "persistent": true,
     "scripts": [
       "background.js",
       "aws-sdk-2.503.min.js"
-    ]
+    ],
+    "persistent": true
   },
   "content_scripts": [
     {
@@ -26,5 +21,13 @@
       "matches": ["https://account.activedirectory.windowsazure.com/*"],
       "js": ["select_app.js"]
     }
+  ],
+  "permissions": [
+    "*://*/*",
+    "contentSettings",
+    "downloads",
+    "tabs",
+    "webRequest",
+    "webRequestBlocking"
   ]
 }

--- a/chrome_extension/manifest.json
+++ b/chrome_extension/manifest.json
@@ -20,6 +20,10 @@
     {
       "matches": ["https://account.activedirectory.windowsazure.com/*"],
       "js": ["select_app.js"]
+    },
+    {
+      "matches": ["https://signin.aws.amazon.com/saml"],
+      "js": ["select_role.js"]
     }
   ],
   "permissions": [

--- a/chrome_extension/select_role.js
+++ b/chrome_extension/select_role.js
@@ -1,0 +1,21 @@
+'use strict';
+
+chrome.runtime.sendMessage({type: "AWS_AD_credentials_get_role", key: "roleArn"}, function(response) {
+    const roleName = response.toUpperCase()
+    if (roleName) {
+        return
+    }
+
+    var inject = function() {
+        var checked = document.querySelectorAll('input[type=radio]:checked');
+        if (checked.length !== 1) {
+            return;
+        }
+        var role = checked[0].id;
+
+        chrome.runtime.sendMessage({type: 'AWS_AD_Credentials_set_role', roleArn: role});
+
+    }
+    document.getElementById('signin_button').addEventListener('click', function(event) { inject(); event.preventDefaut(); return false; })
+})
+


### PR DESCRIPTION
Only `--profile-name` is required anymore. User can decide to give `--app` and/or `--role-arn` as a command line parameter, or select them from browser. `--duration` works the same as optional parameter that defaults to 4 hours.

Please see separate commits for more coherent changes :)